### PR TITLE
Add SIMD subgroup charter

### DIFF
--- a/proposals/flexible-vectors/Charter.md
+++ b/proposals/flexible-vectors/Charter.md
@@ -1,0 +1,58 @@
+# WebAssembly SIMD Subgroup Charter
+
+The SIMD Subgroup is a sub-organization of the
+[WebAssembly Community Group](https://www.w3.org/community/webassembly/)
+of the W3C.
+As such, it is intended that its charter align with that of the CG. In particular, 
+the sections of the [CG charter](https://webassembly.github.io/cg-charter/) relating to
+[Community and Business Group Process](https://webassembly.github.io/cg-charter/#process),
+[Contribution Mechanics](https://webassembly.github.io/cg-charter/#contrib),
+[Transparency](https://webassembly.github.io/cg-charter/#transparency),
+and
+[Decision Process](https://webassembly.github.io/cg-charter/#decision)
+also apply to the Subgroup.
+
+## Goals
+
+The mission of this subgroup is to provide a forum for collaboration on the standardisation of SIMD support for WebAssembly. This is inclusive of the fixed-width SIMD, relaxed-SIMD, and flexible vectors proposals.
+
+## Scope
+
+The Subgroup will consider topics related to SIMD for Wasm, including:
+
+- instruction sets for defining and manipulating vector types,
+- code generation for compilers targeting Wasm with SIMD extensions,
+- performance data for justifying the inclusion of instructions,
+- hardware support for SIMD, as well as ease of use for applications
+
+## Deliverables
+
+### Specifications
+
+The Subgroup may produce several kinds of specification-related work output:
+
+- new specifications in standards bodies or working groups
+  (e.g. W3C WebAssembly WG or Ecma TC39),
+
+- new specifications outside of standards bodies
+  (e.g. similar to the LLVM object file format documentation in Wasm tool conventions).
+
+### Non-normative reports
+
+The Subgroup may produce non-normative material such as requirements
+documents, optimization guides, recommendations, and case studies.
+
+### Software
+
+The Subgroup may produce software related to SIMD in Wasm
+(either as standalone libraries, tooling, or integration of interface-related functionality in existing CG software).
+These may include:
+
+- extensions to the Wasm reference interpreter,
+- extensions to the Wasm test suite,
+- compilers and tools for producing code that uses Wasm SIMD,
+- tools for debugging programs using Wasm SIMD.
+
+## Amendments to this Charter and Chair Selection
+
+This charter may be amended, and Subgroup Chairs may be selected by vote of the full WebAssembly Community Group.

--- a/proposals/flexible-vectors/Charter.md
+++ b/proposals/flexible-vectors/Charter.md
@@ -33,7 +33,6 @@ The Subgroup may produce several kinds of specification-related work output:
 
 - new specifications in standards bodies or working groups
   (e.g. W3C WebAssembly WG or Ecma TC39),
-
 - new specifications outside of standards bodies
   (e.g. similar to the LLVM object file format documentation in Wasm tool conventions).
 


### PR DESCRIPTION
As this is the first time we have separate proposals under the same subgroup - not sure where the charter should live. For now, I'm duplicating the charter here as well as in the relaxed-simd proposal for discoverability, and easy modification in case we decide to split the subgroup based on proposals in the future.