### PR TITLE
Replace `LaneIdx` immediates with integers

### DIFF
--- a/proposals/flexible-vectors/BinaryFlexibleVectors.md
+++ b/proposals/flexible-vectors/BinaryFlexibleVectors.md
@@ -45,32 +45,68 @@ Vector length:
 
 Constructing vectors and accessing lanes:
 
-| Instruction              | `prefix` | `vecop` | Immediate operands       |
-| -------------------------|---------:|--------:|--------------------------|
-| `vec.i8.splat`           |    `0x7A`|   `0x10`| -                        |
-| `vec.i16.splat`          |    `0x79`|   `0x10`| -                        |
-| `vec.i32.splat`          |    `0x78`|   `0x10`| -                        |
-| `vec.i64.splat`          |    `0x77`|   `0x10`| -                        |
-| `vec.f32.splat`          |    `0x76`|   `0x10`| -                        |
-| `vec.f64.splat`          |    `0x75`|   `0x10`| -                        |
-| `vec.i8.extract_lane_u`  |    `0x7A`|   `0x11`| i:ImmLaneIdxV8           |
-| `vec.i16.extract_lane_u` |    `0x79`|   `0x11`| i:ImmLaneIdxV16          |
-| `vec.i32.extract_lane_u` |    `0x78`|   `0x11`| i:ImmLaneIdxV32          |
-| `vec.i64.extract_lane_u` |    `0x77`|   `0x11`| i:ImmLaneIdxV64          |
-| `vec.f32.extract_lane_u` |    `0x76`|   `0x11`| i:ImmLaneIdxV32          |
-| `vec.f64.extract_lane_u` |    `0x75`|   `0x11`| i:ImmLaneIdxV64          |
-| `vec.i8.extract_lane_s`  |    `0x7A`|   `0x12`| i:ImmLaneIdxV8           |
-| `vec.i16.extract_lane_s` |    `0x79`|   `0x12`| i:ImmLaneIdxV16          |
-| `vec.i32.extract_lane_s` |    `0x78`|   `0x12`| i:ImmLaneIdxV32          |
-| `vec.i64.extract_lane_s` |    `0x77`|   `0x12`| i:ImmLaneIdxV64          |
-| `vec.f32.extract_lane_s` |    `0x76`|   `0x12`| i:ImmLaneIdxV32          |
-| `vec.f64.extract_lane_s` |    `0x75`|   `0x12`| i:ImmLaneIdxV64          |
-| `vec.i8.replace_lane`    |    `0x7A`|   `0x13`| i:ImmLaneIdxV8           |
-| `vec.i16.replace_lane`   |    `0x79`|   `0x13`| i:ImmLaneIdxV16          |
-| `vec.i32.replace_lane`   |    `0x78`|   `0x13`| i:ImmLaneIdxV32          |
-| `vec.i64.replace_lane`   |    `0x77`|   `0x13`| i:ImmLaneIdxV64          |
-| `vec.f32.replace_lane`   |    `0x76`|   `0x13`| i:ImmLaneIdxV32          |
-| `vec.f64.replace_lane`   |    `0x75`|   `0x13`| i:ImmLaneIdxV64          |
+| Instruction                  | `prefix` | `vecop` | Immediate operands   |
+| -----------------------------|---------:|--------:|----------------------|
+| `vec.i8.splat`               |    `0x7A`|   `0x10`| -                    |
+| `vec.i16.splat`              |    `0x79`|   `0x10`| -                    |
+| `vec.i32.splat`              |    `0x78`|   `0x10`| -                    |
+| `vec.i64.splat`              |    `0x77`|   `0x10`| -                    |
+| `vec.f32.splat`              |    `0x76`|   `0x10`| -                    |
+| `vec.f64.splat`              |    `0x75`|   `0x10`| -                    |
+| `vec.i8.extract_lane_imm_u`  |    `0x7A`|   `0x11`| i:ImmLaneIdx16       |
+| `vec.i16.extract_lane_imm_u` |    `0x79`|   `0x11`| i:ImmLaneIdx8        |
+| `vec.i32.extract_lane_imm_u` |    `0x78`|   `0x11`| i:ImmLaneIdx4        |
+| `vec.i64.extract_lane_imm_u` |    `0x77`|   `0x11`| i:ImmLaneIdx2        |
+| `vec.f32.extract_lane_imm_u` |    `0x76`|   `0x11`| i:ImmLaneIdx4        |
+| `vec.f64.extract_lane_imm_u` |    `0x75`|   `0x11`| i:ImmLaneIdx2        |
+| `vec.i8.extract_lane_imm_s`  |    `0x7A`|   `0x12`| i:ImmLaneIdx16       |
+| `vec.i16.extract_lane_imm_s` |    `0x79`|   `0x12`| i:ImmLaneIdx8        |
+| `vec.i32.extract_lane_imm_s` |    `0x78`|   `0x12`| i:ImmLaneIdx4        |
+| `vec.i64.extract_lane_imm_s` |    `0x77`|   `0x12`| i:ImmLaneIdx2        |
+| `vec.f32.extract_lane_imm_s` |    `0x76`|   `0x12`| i:ImmLaneIdx4        |
+| `vec.f64.extract_lane_imm_s` |    `0x75`|   `0x12`| i:ImmLaneIdx2        |
+| `vec.i8.replace_lane_imm`    |    `0x7A`|   `0x13`| i:ImmLaneIdx16       |
+| `vec.i16.replace_lane_imm`   |    `0x79`|   `0x13`| i:ImmLaneIdx8        |
+| `vec.i32.replace_lane_imm`   |    `0x78`|   `0x13`| i:ImmLaneIdx4        |
+| `vec.i64.replace_lane_imm`   |    `0x77`|   `0x13`| i:ImmLaneIdx2        |
+| `vec.f32.replace_lane_imm`   |    `0x76`|   `0x13`| i:ImmLaneIdx4        |
+| `vec.f64.replace_lane_imm`   |    `0x75`|   `0x13`| i:ImmLaneIdx2        |
+| `vec.i8.extract_lane_u`      |    `0x7A`|   `0x14`| -                    |
+| `vec.i16.extract_lane_u`     |    `0x79`|   `0x14`| -                    |
+| `vec.i32.extract_lane_u`     |    `0x78`|   `0x14`| -                    |
+| `vec.i64.extract_lane_u`     |    `0x77`|   `0x14`| -                    |
+| `vec.f32.extract_lane_u`     |    `0x76`|   `0x14`| -                    |
+| `vec.f64.extract_lane_u`     |    `0x75`|   `0x14`| -                    |
+| `vec.i8.extract_lane_s`      |    `0x7A`|   `0x15`| -                    |
+| `vec.i16.extract_lane_s`     |    `0x79`|   `0x15`| -                    |
+| `vec.i32.extract_lane_s`     |    `0x78`|   `0x15`| -                    |
+| `vec.i64.extract_lane_s`     |    `0x77`|   `0x15`| -                    |
+| `vec.f32.extract_lane_s`     |    `0x76`|   `0x15`| -                    |
+| `vec.f64.extract_lane_s`     |    `0x75`|   `0x15`| -                    |
+| `vec.i8.replace_lane`        |    `0x7A`|   `0x16`| -                    |
+| `vec.i16.replace_lane`       |    `0x79`|   `0x16`| -                    |
+| `vec.i32.replace_lane`       |    `0x78`|   `0x16`| -                    |
+| `vec.i64.replace_lane`       |    `0x77`|   `0x16`| -                    |
+| `vec.f32.replace_lane`       |    `0x76`|   `0x16`| -                    |
+| `vec.f64.replace_lane`       |    `0x75`|   `0x16`| -                    |
+| `vec.i8.extract_lane_mod_u`  |    `0x7A`|   `0x17`| -                    |
+| `vec.i16.extract_lane_mod_u` |    `0x79`|   `0x17`| -                    |
+| `vec.i32.extract_lane_mod_u` |    `0x78`|   `0x17`| -                    |
+| `vec.i64.extract_lane_mod_u` |    `0x77`|   `0x17`| -                    |
+| `vec.f32.extract_lane_mod_u` |    `0x76`|   `0x17`| -                    |
+| `vec.f64.extract_lane_mod_u` |    `0x75`|   `0x17`| -                    |
+| `vec.i8.extract_lane_mod_s`  |    `0x7A`|   `0x18`| -                    |
+| `vec.i16.extract_lane_mod_s` |    `0x79`|   `0x18`| -                    |
+| `vec.i32.extract_lane_mod_s` |    `0x78`|   `0x18`| -                    |
+| `vec.i64.extract_lane_mod_s` |    `0x77`|   `0x18`| -                    |
+| `vec.f32.extract_lane_mod_s` |    `0x76`|   `0x18`| -                    |
+| `vec.f64.extract_lane_mod_s` |    `0x75`|   `0x18`| -                    |
+| `vec.i8.replace_lane_mod`    |    `0x7A`|   `0x19`| -                    |
+| `vec.i16.replace_lane_mod`   |    `0x79`|   `0x19`| -                    |
+| `vec.i32.replace_lane_mod`   |    `0x78`|   `0x19`| -                    |
+| `vec.i64.replace_lane_mod`   |    `0x77`|   `0x19`| -                    |
+| `vec.f32.replace_lane_mod`   |    `0x76`|   `0x19`| -                    |
+| `vec.f64.replace_lane_mod`   |    `0x75`|   `0x19`| -                    |
 
 Shuffles:
 

--- a/proposals/flexible-vectors/FlexibleVectors.md
+++ b/proposals/flexible-vectors/FlexibleVectors.md
@@ -54,14 +54,17 @@ the following differences applying to overall types:
 - Number of lanes is set separately for different lane sizes
 - Vectors with different lane size are not immediately interoperable
 
-## Immediate operands
+## Lane index operands compatible with SIMD
 
-_TBD_ value range, depends on instruction encoding.
+Some operations acess lanes within part of the vector compatible to existing
+SIMD standard. Those operands have a limited valid range, and it is a
+validation error if the immediate operands are out of range.
 
-- `ImmLaneIdxV8`: lane index for 8-bit lanes
-- `ImmLaneIdxV16`: lane index for 16-bit lanes
-- `ImmLaneIdxV32`: lane index for 32-bit lanes
-- `ImmLaneIdxV64`: lane index for 64-bit lanes
+* `ImmLaneIdx2`: A byte with values in the range 0–1 identifying a lane.
+* `ImmLaneIdx4`: A byte with values in the range 0–3 identifying a lane.
+* `ImmLaneIdx8`: A byte with values in the range 0–7 identifying a lane.
+* `ImmLaneIdx16`: A byte with values in the range 0–15 identifying a lane.
+* `ImmLaneIdx32`: A byte with values in the range 0–31 identifying a lane.
 
 ## Operations
 
@@ -102,20 +105,21 @@ def S.splat(x):
 
 ### Accessing lanes
 
-#### Extract lane as a scalar
+#### Extract lane as a scalar using limited immediate index
 
-- `vec.i8.extract_lane_s(a: vec.i8, imm: ImmLaneIdxV8) -> i32`
-- `vec.i8.extract_lane_u(a: vec.i8, imm: ImmLaneIdxV8) -> i32`
-- `vec.i16.extract_lane_s(a: vec.i16, imm: ImmLaneIdxV16) -> i32`
-- `vec.i16.extract_lane_u(a: vec.i16, imm: ImmLaneIdxV16) -> i32`
-- `vec.i32.extract_lane(a: vec.i32, imm: ImmLaneIdxV32) -> i32`
-- `vec.i64.extract_lane(a: vec.i64, imm: ImmLaneIdxV64) -> i64`
-- `vec.f32.extract_lane(a: vec.f32, imm: ImmLaneIdxV32) -> f32`
-- `vec.f64.extract_lane(a: vec.f64, imm: ImmLaneIdxV64) -> f64`
+- `vec.i8.extract_lane_imm_s(a: vec.i8, imm: ImmLaneIdx16) -> i32`
+- `vec.i8.extract_lane_imm_u(a: vec.i8, imm: ImmLaneIdx16) -> i32`
+- `vec.i16.extract_lane_imm_s(a: vec.i16, imm: ImmLaneIdx8) -> i32`
+- `vec.i16.extract_lane_imm_u(a: vec.i16, imm: ImmLaneIdx8) -> i32`
+- `vec.i32.extract_lane_imm(a: vec.i32, imm: ImmLaneIdx4) -> i32`
+- `vec.i64.extract_lane_imm(a: vec.i64, imm: ImmLaneIdx2) -> i64`
+- `vec.f32.extract_lane_imm(a: vec.f32, imm: ImmLaneIdx4) -> f32`
+- `vec.f64.extract_lane_imm(a: vec.f64, imm: ImmLaneIdx2) -> f64`
 
 Extract the scalar value of lane specified in the immediate mode operand `imm`
 in `a`. The `{interpretation}.extract_lane{_s}{_u}` instructions are encoded
-with one immediate byte providing the index of the lane to extract.
+with one immediate byte providing the index of the lane to extract. Index
+values outside lower 128 bits of the vector result in a validation error.
 
 ```python
 def S.extract_lane(a, i):
@@ -125,19 +129,20 @@ def S.extract_lane(a, i):
 The `_s` and `_u` variants will sign-extend or zero-extend the lane value to
 `i32` respectively.
 
-#### Replace lane value
+#### Replace lane using limited immediate index
 
-- `vec.i8.replace_lane(a: vec.i8, imm: ImmLaneIdxV8, x: i32) -> vec.i8`
-- `vec.i16.replace_lane(a: vec.i16, imm: ImmLaneIdxV16, x: i32) -> vec.i16`
-- `vec.i32.replace_lane(a: vec.i32, imm: ImmLaneIdxV32, x: i32) -> vec.i32`
-- `vec.i64.replace_lane(a: vec.i64, imm: ImmLaneIdxV64, x: i64) -> vec.i64`
-- `vec.f32.replace_lane(a: vec.f32, imm: ImmLaneIdxV32, x: f32) -> vec.f32`
-- `vec.f64.replace_lane(a: vec.f64, imm: ImmLaneIdxV64, x: f64) -> vec.f64`
+- `vec.i8.replace_lane_imm(a: vec.i8, imm: ImmLaneIdx16, x: i32) -> vec.i8`
+- `vec.i16.replace_lane_imm(a: vec.i16, imm: ImmLaneIdx8, x: i32) -> vec.i16`
+- `vec.i32.replace_lane_imm(a: vec.i32, imm: ImmLaneIdx4, x: i32) -> vec.i32`
+- `vec.i64.replace_lane_imm(a: vec.i64, imm: ImmLaneIdx2, x: i64) -> vec.i64`
+- `vec.f32.replace_lane_imm(a: vec.f32, imm: ImmLaneIdx4, x: f32) -> vec.f32`
+- `vec.f64.replace_lane_imm(a: vec.f64, imm: ImmLaneIdx2, x: f64) -> vec.f64`
 
 Return a new vector with lanes identical to `a`, except for the lane specified
 in the immediate mode operand `imm` which has the value `x`. The
 `{interpretation}.replace_lane` instructions are encoded with an immediate byte 
-providing the index of the lane the value of which is to be replaced.
+providing the index of the lane the value of which is to be replaced. Index
+values outside lower 128 bits of the vector result in a validation error.
 
 ```python
 def S.replace_lane(a, i, x):

--- a/proposals/flexible-vectors/FlexibleVectorsSecondTier.md
+++ b/proposals/flexible-vectors/FlexibleVectorsSecondTier.md
@@ -6,6 +6,137 @@ performance data. The reasons are listed in "implementation notes" sections.
 
 ## Operations
 
+### Accessing lanes
+
+#### Extract lane as a scalar
+
+- `vec.i8.extract_lane_s(a: vec.i8, idx: i32) -> i32`
+- `vec.i8.extract_lane_u(a: vec.i8, idx: i32) -> i32`
+- `vec.i16.extract_lane_s(a: vec.i16, idx: i32) -> i32`
+- `vec.i16.extract_lane_u(a: vec.i16, idx: i32) -> i32`
+- `vec.i32.extract_lane(a: vec.i32, idx: i32) -> i32`
+- `vec.i64.extract_lane(a: vec.i64, idx: i32) -> i64`
+- `vec.f32.extract_lane(a: vec.f32, idx: i32) -> f32`
+- `vec.f64.extract_lane(a: vec.f64, idx: i32) -> f64`
+
+Extract the scalar value of lane specified in `idx` operand in `a`. Trap if the
+index is out of bounds for the vector type.
+
+```python
+def S.extract_lane(a, i):
+    assert(i < S.Lanes)
+    return a[i]
+```
+
+The `_s` and `_u` variants will sign-extend or zero-extend the lane value to
+`i32` respectively.
+
+<details>
+  <summary>Implementation notes</summary>
+
+  Ensuring that lane index is within bounds requires a runtime check. Such
+  check can be elided, but would require at least some dataflow analysis.
+
+</details>
+
+#### Replace lane value
+
+- `vec.i8.replace_lane(a: vec.i8, idx: i32, x: i32) -> vec.i8`
+- `vec.i16.replace_lane(a: vec.i16, idx: i32, x: i32) -> vec.i16`
+- `vec.i32.replace_lane(a: vec.i32, idx: i32, x: i32) -> vec.i32`
+- `vec.i64.replace_lane(a: vec.i64, idx: i32, x: i64) -> vec.i64`
+- `vec.f32.replace_lane(a: vec.f32, idx: i32, x: f32) -> vec.f32`
+- `vec.f64.replace_lane(a: vec.f64, idx: i32, x: f64) -> vec.f64`
+
+Return a new vector with lanes identical to `a`, except for the lane specified
+by `idx` operand which gets the value `x`. Trap if the index is out of bounds
+for the vector type.
+
+```python
+def S.replace_lane(a, i, x):
+    assert(i < S.Lanes)
+    result = S.New()
+    for j in range(S.Lanes):
+        result[j] = a[j]
+    result[i] = x
+    return result
+```
+
+The input lane value, `x`, is interpreted the same way as for the splat
+instructions. For the `i8` and `i16` lanes, the high bits of `x` are ignored.
+
+<details>
+  <summary>Implementation notes</summary>
+
+  Ensuring that lane index is within bounds requires a runtime check. Such
+  check can be elided, but would require at least some dataflow analysis.
+
+</details>
+
+#### Extract lane as a scalar, modulo lane count
+
+- `vec.i8.extract_lane_mod_s(a: vec.i8, idx: i32) -> i32`
+- `vec.i8.extract_lane_mod_u(a: vec.i8, idx: i32) -> i32`
+- `vec.i16.extract_lane_mod_s(a: vec.i16, idx: i32) -> i32`
+- `vec.i16.extract_lane_mod_u(a: vec.i16, idx: i32) -> i32`
+- `vec.i32.extract_lane_mod(a: vec.i32, idx: i32) -> i32`
+- `vec.i64.extract_lane_mod(a: vec.i64, idx: i32) -> i64`
+- `vec.f32.extract_lane_mod(a: vec.f32, idx: i32) -> f32`
+- `vec.f64.extract_lane_mod(a: vec.f64, idx: i32) -> f64`
+
+Extract the scalar value of lane specified in `idx` operand in `a`, modulo the
+number of lanes.
+
+```python
+def S.extract_lane_mod(a, i):
+    return a[i % S.Lanes]
+```
+
+The `_s` and `_u` variants will sign-extend or zero-extend the lane value to
+`i32` respectively.
+
+<details>
+  <summary>Implementation notes</summary>
+
+  Taking index modulo the lane count would add an extra operation, which may or
+  may not be elided. Additional concern is that modulo semantics are
+  potentially more confusing than checked semantics.
+
+</details>
+
+#### Replace lane value, modulo lane count
+
+- `vec.i8.replace_lane_mod(a: vec.i8, idx: i32, x: i32) -> vec.i8`
+- `vec.i16.replace_lane_mod(a: vec.i16, idx: i32, x: i32) -> vec.i16`
+- `vec.i32.replace_lane_mod(a: vec.i32, idx: i32, x: i32) -> vec.i32`
+- `vec.i64.replace_lane_mod(a: vec.i64, idx: i32, x: i64) -> vec.i64`
+- `vec.f32.replace_lane_mod(a: vec.f32, idx: i32, x: f32) -> vec.f32`
+- `vec.f64.replace_lane_mod(a: vec.f64, idx: i32, x: f64) -> vec.f64`
+
+Return a new vector with lanes identical to `a`, except for the lane specified
+by `idx` operand which gets the value `x`, taken modulo the number of lanes.
+
+```python
+def S.replace_lane_mod(a, i, x):
+    result = S.New()
+    for j in range(S.Lanes):
+        result[j] = a[j]
+    result[i % S.Lanes] = x
+    return result
+```
+
+The input lane value, `x`, is interpreted the same way as for the splat
+instructions. For the `i8` and `i16` lanes, the high bits of `x` are ignored.
+
+<details>
+  <summary>Implementation notes</summary>
+
+  Taking index modulo the lane count would add an extra operation, which may or
+  may not be elided. Additional concern is that modulo semantics are
+  potentially more confusing than checked semantics.
+
+</details>
+
 ### Floating-point min and max
 
 These operations are not part of the IEEE 754-2008 standard. They are lane-wise
@@ -14,8 +145,8 @@ versions of the existing scalar WebAssembly operations.
 <details>
   <summary>Implementation notes</summary>
 
-  NaN queting required for these operation is expensive on x86-based platforms.
-  See [WebAssembly/simd#186](https://github.com/WebAssembly/simd/issues/186).
+  NaN queting required for these operation is expensive on x86-based platforms,
+  at least without AVX512. See [WebAssembly/simd#186](https://github.com/WebAssembly/simd/issues/186).
 
 </details>
 

--- a/proposals/flexible-vectors/FlexibleVectorsThirdTier.md
+++ b/proposals/flexible-vectors/FlexibleVectorsThirdTier.md
@@ -22,20 +22,20 @@ reasons are listed in "implementation notes" sections.
 
 - 8-bit lanes
   - `vec.i8.set_length(len: i32) -> i32`
-  - `vec.i8.set_length_imm(imm: ImmLaneIdx8) -> i32`
+  - `vec.i8.set_length_imm(idx: i32) -> i32`
 - 16-bit lanes
   - `vec.i16.set_length(len: i32) -> i32`
-  - `vec.i16.set_length_imm(imm: ImmLaneIdx16) -> i32`
+  - `vec.i16.set_length_imm(idx: i32) -> i32`
 - 32-bit lanes
   - `vec.i32.set_length(len: i32) -> i32`
-  - `vec.i32.set_length_imm(imm: ImmLaneIdx32) -> i32`
+  - `vec.i32.set_length_imm(idx: i32) -> i32`
   - `vec.f32.set_length(len: i32) -> i32`
-  - `vec.f32.set_length_imm(imm: ImmLaneIdx32) -> i32`
+  - `vec.f32.set_length_imm(idx: i32) -> i32`
 - 64-bit lanes
   - `vec.i64.set_length(len: i32) -> i32`
-  - `vec.i64.set_length_imm(imm: ImmLaneIdx64) -> i32`
+  - `vec.i64.set_length_imm(idx: i32) -> i32`
   - `vec.f64.set_length(len: i32) -> i32`
-  - `vec.f64.set_length_imm(imm: ImmLaneIdx64) -> i32`
+  - `vec.f64.set_length_imm(idx: i32) -> i32`
 
 The above operations set the number of lanes for corresponding vector type to
 the minimum of supported vector length and the requested length. The length is


### PR DESCRIPTION
Change current extract and replace lane operations to use immediate
indices _within lower 128 bits of the vector_ (compatible to current
standard). Keep description of immediates identical to what is used in
current SIMD.

Add two more flavors for extract and replace lane operations: one
containing a bounds check and the other taking the index value modulo
number of lanes in the vector.

Update opcodes to reflect new operations and changes in the names.

Minor housekeeping: set length should take an immediate, note on AVX512.